### PR TITLE
Fix double click of menu causing scroll issue.

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -30,10 +30,17 @@ jQuery(document).ready(function ($) {
         }
     });
 
+	var doneScrolling = true;
     function goToByScroll(dataslide) {
-        htmlbody.animate({
-            scrollTop: $('.slide[data-slide="' + dataslide + '"]').offset().top
-        }, 2000, 'easeInOutQuint');
+    	if(doneScrolling){
+    		doneScrolling = false;
+			htmlbody.animate({
+	            scrollTop: $('.slide[data-slide="' + dataslide + '"]').offset().top
+	        }, 2000, 'easeInOutQuint', function(){
+	        	doneScrolling = true;
+	        });
+    	}
+        
     }
 
 


### PR DESCRIPTION
Try double clicking any menu item here:
http://jalxob.com/cool-kitten/

And once the animation is finished scrolling try to scroll up before scrolling down. You'll see the screen is locked. This is a fix for that.

I created a call back function to tell us when the animation is finished which reduces the pile up of multiple requests.
